### PR TITLE
Fix wdl filtering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viriformat"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 license = "MIT"
 description = "A library for the data-representation used by the viridithas chess engine."

--- a/src/dataformat.rs
+++ b/src/dataformat.rs
@@ -172,7 +172,7 @@ impl Filter {
             return true;
         }
         if self.wdl_filtered
-            && rng.random_bool(self.result_chance(board.material_count(), eval, wdl))
+            && rng.random_bool(1.0 - self.result_chance(board.material_count(), eval, wdl))
         {
             return true;
         }


### PR DESCRIPTION
Positions are meant to be filtered when the result doesn't agree with the model, which means the probability of filtering should be higher the less probable the result is, in other words `1 - result_change`.